### PR TITLE
fix: the recursive option is not working in the bump.config.ts file

### DIFF
--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -41,7 +41,7 @@ export async function parseArgs(): Promise<ParsedArgs> {
         ignoreScripts: args.ignoreScripts,
         currentVersion: args.currentVersion,
         execute: args.execute,
-        recursive: !!args.recursive,
+        recursive: args.recursive,
       }),
     }
 


### PR DESCRIPTION
### Description

If the `recursive` option is not specified, let it be `undefined`.

### Linked Issues

Fix #41 

### Additional context
