### PR TITLE
feat: check git status before bump if option.all is falsy

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -29,7 +29,7 @@ export async function main(): Promise<void> {
       process.exit(ExitCode.Success)
     }
     else {
-      if (!options.all) {
+      if (!options.all && !options.noGitCheck) {
         checkGitStatus()
       }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,6 @@
 import process from 'node:process'
 import symbols from 'log-symbols'
+import * as ezSpawn from '@jsdevtools/ez-spawn'
 import { version as packageVersion } from '../../package.json'
 import type { VersionBumpProgress } from '../types/version-bump-progress'
 import { ProgressEvent } from '../types/version-bump-progress'
@@ -28,6 +29,10 @@ export async function main(): Promise<void> {
       process.exit(ExitCode.Success)
     }
     else {
+      if (!options.all) {
+        checkGitStatus()
+      }
+
       if (!quiet)
         options.progress = options.progress ? options.progress : progress
 
@@ -36,6 +41,13 @@ export async function main(): Promise<void> {
   }
   catch (error) {
     errorHandler(error as Error)
+  }
+}
+
+export function checkGitStatus() {
+  const { stdout } = ezSpawn.sync('git', ['status', '--porcelain'])
+  if (stdout.trim()) {
+    throw new Error(`Git working tree is not clean:\n${stdout}`)
   }
 }
 

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -35,6 +35,7 @@ export async function parseArgs(): Promise<ParsedArgs> {
         tag: args.tag,
         push: args.push,
         all: args.all,
+        noGitCheck: args.noGitCheck,
         confirm: !args.yes,
         noVerify: !args.verify,
         files: [...(args['--'] || []), ...resultArgs],
@@ -74,6 +75,7 @@ export function loadCliArgs(argv = process.argv) {
     .usage('[...files]')
     .option('--preid <preid>', 'ID for prerelease')
     .option('--all', `Include all files (default: ${bumpConfigDefaults.all})`)
+    .option('--no-git-check', `Skip git check`, { default: bumpConfigDefaults.noGitCheck })
     .option('-c, --commit [msg]', 'Commit message', { default: true })
     .option('--no-commit', 'Skip commit', { default: false })
     .option('-t, --tag [tag]', 'Tag name', { default: true })

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export const bumpConfigDefaults: VersionBumpOptions = {
   confirm: true,
   ignoreScripts: false,
   all: false,
+  noGitCheck: true,
   files: [],
 }
 

--- a/src/types/version-bump-options.ts
+++ b/src/types/version-bump-options.ts
@@ -65,6 +65,13 @@ export interface VersionBumpOptions {
   all?: boolean
 
   /**
+   * Indicates whether the git working tree needs to be cleared before bumping.
+   *
+   * Defaults to `true`.
+   */
+  noGitCheck?: boolean
+
+  /**
    * Prompt for confirmation
    *
    * @default true


### PR DESCRIPTION
### Description

enable **git status check**  if `options.all` is falsy

### Linked Issues

resolved #43