### PR TITLE
feat: execute could receive a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Forked from [`version-bump-prompt`](https://github.com/JS-DevTools/version-bump-
 
 - Renamed to `bumpp` - so you can use `npx bumpp` directly.
 - Ships ESM and CJS bundles.
-- Add a new argument `--execute` to execute the command before committing.
+- Add a new argument `--execute` to execute the command, or execute a function before committing.
 - Use the current version's `preid` when available.
 - Confirmation before bumping.
 - Enable `--commit` `--tag` `--push` by default. (opt-out by `--no-push`, etc.)
@@ -23,5 +23,8 @@ import { defineConfig } from 'bumpp'
 
 export default defineConfig({
   // ...options
+  execute(config) {
+    // ...`execute` could receive a function here
+  }
 })
 ```

--- a/src/normalize-options.ts
+++ b/src/normalize-options.ts
@@ -1,10 +1,11 @@
+import type { Operation } from './operation'
 import type { ReleaseType } from './release-type'
 import type { VersionBumpOptions } from './types/version-bump-options'
 import fsSync from 'node:fs'
 import fs from 'node:fs/promises'
 import process from 'node:process'
-import { glob } from 'tinyglobby'
 import yaml from 'js-yaml'
+import { glob } from 'tinyglobby'
 import { isReleaseType } from './release-type'
 
 interface Interface {
@@ -61,7 +62,7 @@ export interface NormalizedOptions {
   cwd: string
   interface: Interface
   ignoreScripts: boolean
-  execute?: string
+  execute?: string | ((config?: Operation) => void | PromiseLike<void>)
   printCommits?: boolean
   customVersion?: VersionBumpOptions['customVersion']
   currentVersion?: string

--- a/src/types/version-bump-options.ts
+++ b/src/types/version-bump-options.ts
@@ -1,4 +1,5 @@
 import type _semver from 'semver'
+import type { Operation } from '../operation'
 import type { VersionBumpProgress } from './version-bump-progress'
 
 /**
@@ -135,7 +136,7 @@ export interface VersionBumpOptions {
   /**
    * Excute additional command after bumping and before commiting
    */
-  execute?: string
+  execute?: string | ((config?: Operation) => void | PromiseLike<void>)
 
   /**
    * Bump the files recursively for monorepo. Only works without `files` option.

--- a/src/version-bump.ts
+++ b/src/version-bump.ts
@@ -72,9 +72,14 @@ export async function versionBump(arg: (VersionBumpOptions) | string = {}): Prom
   await updateFiles(operation)
 
   if (operation.options.execute) {
-    console.log(symbols.info, 'Executing script', operation.options.execute)
-    await ezSpawn.async(operation.options.execute, { stdio: 'inherit' })
-    console.log(symbols.success, 'Script finished')
+    if (typeof operation.options.execute === 'function') {
+      await operation.options.execute(operation)
+    }
+    else {
+      console.log(symbols.info, 'Executing script', operation.options.execute)
+      await ezSpawn.async(operation.options.execute, { stdio: 'inherit' })
+      console.log(symbols.success, 'Script finished')
+    }
   }
 
   // Run npm version script, if any
@@ -101,7 +106,7 @@ function printSummary(operation: Operation) {
   if (operation.options.tag)
     console.log(`     tag ${c.bold(formatVersionString(operation.options.tag.name, operation.state.newVersion))}`)
   if (operation.options.execute)
-    console.log(` execute ${c.bold(operation.options.execute)}`)
+    console.log(` execute ${c.bold(typeof operation.options.execute === 'function' ? 'function' : operation.options.execute)}`)
   if (operation.options.push)
     console.log(`    push ${c.cyan(c.bold('yes'))}`)
   console.log()


### PR DESCRIPTION
### Description

The PR makes `execute` option could receive a function.

```
pnpm bumpp --execute="echo foo"
```

```ts
export defualt defineConfig({
  execute: 'echo foo'
})
```

It does not change the before behavior. But it makes users could pass a function in `bump.config.ts`:

```ts
export defualt defineConfig({
  // execute: 'echo foo'

  execute: (config) => {
    console.log('bar', config.results.newVersion)
    // also could be an async function
  }
})
```

### Linked Issues

Closes #53.  Related #10.

### Additional context

The log messages may need improvement:
`src/version-bump.ts`
```
console.log(` execute ${c.bold(typeof operation.options.execute === 'function' ? 'function' : operation.options.execute)}`)
```
