### PR TITLE
fix: remove the useless option 'version'

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,8 +1,7 @@
 import type { VersionBumpProgress } from '../types/version-bump-progress'
 import process from 'node:process'
-import symbols from 'log-symbols'
 import * as ezSpawn from '@jsdevtools/ez-spawn'
-import { version as packageVersion } from '../../package.json'
+import symbols from 'log-symbols'
 import { ProgressEvent } from '../types/version-bump-progress'
 import { versionBump } from '../version-bump'
 import { ExitCode } from './exit-code'
@@ -20,12 +19,8 @@ export async function main(): Promise<void> {
     // Parse the command-line arguments
     const { help, version, quiet, options } = await parseArgs()
 
-    if (help) {
-      process.exit(ExitCode.Success)
-    }
-    else if (version) {
-      // Show the version number and exit
-      console.log(packageVersion)
+    if (help || version) {
+      // Will be handled by cac, just need to exit
       process.exit(ExitCode.Success)
     }
     else {

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -88,7 +88,6 @@ export function loadCliArgs(argv = process.argv) {
     .option('--no-verify', 'Skip git verification')
     .option('--ignore-scripts', `Ignore scripts (default: ${bumpConfigDefaults.ignoreScripts})`)
     .option('-q, --quiet', 'Quiet mode')
-    .option('-v, --version <version>', 'Target version')
     .option('--current-version <version>', 'Current version')
     .option('--print-commits', 'Print recent commits', { default: true })
     .option('-x, --execute <command>', 'Commands to execute after version bumps')


### PR DESCRIPTION
### Description
Remove the useless option 'version'

### Linked Issues
fix #51 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
