### PR TITLE
fix: `execute` type fix.

### DIFF
--- a/src/normalize-options.ts
+++ b/src/normalize-options.ts
@@ -62,7 +62,7 @@ export interface NormalizedOptions {
   cwd: string
   interface: Interface
   ignoreScripts: boolean
-  execute?: string | ((config?: Operation) => void | PromiseLike<void>)
+  execute?: string | ((config: Operation) => void | PromiseLike<void>)
   printCommits?: boolean
   customVersion?: VersionBumpOptions['customVersion']
   currentVersion?: string

--- a/src/types/version-bump-options.ts
+++ b/src/types/version-bump-options.ts
@@ -134,9 +134,9 @@ export interface VersionBumpOptions {
   progress?: (progress: VersionBumpProgress) => void
 
   /**
-   * Excute additional command after bumping and before commiting
+   * Execute additional command after bumping and before committing
    */
-  execute?: string | ((config?: Operation) => void | PromiseLike<void>)
+  execute?: string | ((config: Operation) => void | PromiseLike<void>)
 
   /**
    * Bump the files recursively for monorepo. Only works without `files` option.


### PR DESCRIPTION
### Description

The only position where used `execute` function is [here](https://github.com/antfu-collective/bumpp/blob/main/src/version-bump.ts#L76). So the param will never be undefined.

### Linked Issues
 
n/a

### Additional context

And fixed some typos in comments.
