### PR TITLE
fix: --exec ENOENT tinyexec args, close #62

### DIFF
--- a/src/version-bump.ts
+++ b/src/version-bump.ts
@@ -77,9 +77,11 @@ export async function versionBump(arg: (VersionBumpOptions) | string = {}): Prom
     }
     else {
       console.log(symbols.info, 'Executing script', operation.options.execute)
-      await x(operation.options.execute, [], {
+      const [command, ...args] = operation.options.execute.split(' ')
+      await x(command, args, {
         nodeOptions: {
           stdio: 'inherit',
+          cwd: operation.options.cwd,
         },
       })
       console.log(symbols.success, 'Script finished')

--- a/test/exec.test.ts
+++ b/test/exec.test.ts
@@ -1,0 +1,23 @@
+import { existsSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { cwd } from 'node:process'
+import { expect, it } from 'vitest'
+import { versionBump } from '../src'
+
+const distDir = join(cwd(), 'test', 'fixture', 'dist')
+
+it('exec command to clean dist dir', async () => {
+  if (!existsSync(distDir)) {
+    await mkdir(distDir)
+  }
+
+  expect(existsSync(distDir)).toBeTruthy()
+  await versionBump({
+    cwd: join(cwd(), 'test', 'fixture'),
+    release: '0.0.1',
+    confirm: false,
+    execute: 'npm run clean',
+  })
+  expect(existsSync(distDir)).toBeFalsy()
+})

--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.0.1",
+  "scripts": {
+    "clean": "rimraf dist"
+  }
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`--exec="command"` will throw error `ENOENT`.

Caused by this commit: https://github.com/antfu-collective/bumpp/commit/780b7cc

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://github.com/antfu-collective/bumpp/issues/62

### Additional context

Add `exec.test.ts` to test `--exec`.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
