### PR TITLE
chore: upgrade args-tokenizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/node": "^22.10.1",
     "@types/prompts": "^2.4.9",
     "@types/semver": "^7.5.8",
-    "args-tokenizer": "^0.2.0",
+    "args-tokenizer": "^0.2.1",
     "eslint": "^9.16.0",
     "esno": "^4.8.0",
     "log-symbols": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^7.5.8
         version: 7.5.8
       args-tokenizer:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       eslint:
         specifier: ^9.16.0
         version: 9.16.0(jiti@2.4.1)
@@ -1082,8 +1082,8 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  args-tokenizer@0.2.0:
-    resolution: {integrity: sha512-R4HL7zpFdNpaNnqvtkHhFwzQhEFWhmYz4dC6W0CEzjxu4OBjobsrpOoBiiW5UINlzVQuU0inVPRSXRRT9bKV2Q==}
+  args-tokenizer@0.2.1:
+    resolution: {integrity: sha512-1hd00qLJxfSYLirIJherrIBbLkpYlLttu2lxQvVJWY+ohZgEZ2Sf9Rnsx5C1kQNo22eb9tV8/l8TWpjYKtwNIw==}
 
   array-differ@3.0.0:
     resolution: {integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==}
@@ -4184,7 +4184,7 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  args-tokenizer@0.2.0: {}
+  args-tokenizer@0.2.1: {}
 
   array-differ@3.0.0: {}
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Looks like tsx requires esm package to have default export condition to run.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://github.com/antfu-collective/bumpp/pull/64

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
