### PR TITLE
chore: move args-tokenizer to direct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "args-tokenizer": "^0.3.0",
     "c12": "^2.0.1",
     "cac": "^6.7.14",
     "escalade": "^3.2.0",
@@ -80,7 +81,6 @@
     "@types/node": "^22.10.10",
     "@types/prompts": "^2.4.9",
     "@types/semver": "^7.5.8",
-    "args-tokenizer": "^0.3.0",
     "eslint": "^9.19.0",
     "esno": "^4.8.0",
     "picocolors": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      args-tokenizer:
+        specifier: ^0.3.0
+        version: 0.3.0
       c12:
         specifier: ^2.0.1
         version: 2.0.1
@@ -54,9 +57,6 @@ importers:
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
-      args-tokenizer:
-        specifier: ^0.3.0
-        version: 0.3.0
       eslint:
         specifier: ^9.19.0
         version: 9.19.0(jiti@2.4.2)


### PR DESCRIPTION
### Description

Since the project is moved to esm only
we can moved args-tokenizer to direct dependencies to reflect its download count.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
