### PR TITLE
fix: consider packages key existence in pnpm-workspace.yaml

### DIFF
--- a/src/normalize-options.ts
+++ b/src/normalize-options.ts
@@ -126,9 +126,9 @@ export async function normalizeOptions(raw: VersionBumpOptions): Promise<Normali
       // read pnpm-workspace.yaml
       const pnpmWorkspace = await fs.readFile('pnpm-workspace.yaml', 'utf8')
       // parse yaml
-      const workspaces = yaml.parse(pnpmWorkspace) as { packages: string[] }
+      const workspaces = yaml.parse(pnpmWorkspace) as { packages?: string[] }
       // append package.json to each workspace string
-      const workspacesWithPackageJson = workspaces.packages.map(workspace => `${workspace}/package.json`)
+      const workspacesWithPackageJson = (workspaces.packages ?? []).map(workspace => `${workspace}/package.json`)
       // start with ! or already in files should be excluded
       const withoutExcludedWorkspaces = workspacesWithPackageJson.filter(workspace => !workspace.startsWith('!') && !raw.files?.includes(workspace))
       // add to files


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

This PR allows bumpp to work properly in repositories where pnpm-workspace.yaml exists but not in a mono-repo configuration.

### Description

In the latest version of pnpm, settings that were previously written under `pnpm` in `package.json` are now written in `pnpm-workspace.yaml`, as shown below.

```yaml
onlyBuiltDependencies:
  - esbuild

patchedDependencies:
  bumpp: patches/bumpp.patch
```

Therefore, even if `pnpm-workspace.yaml` exists, it may not have a `packages` key.
So we must consider the case where the packages key is missing

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
