### PR TITLE
feat: support workspace package in npm/bun lock file

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.14.1",
+    "@types/bun": "^1.2.16",
     "@types/node": "^24.0.3",
     "@types/prompts": "^2.4.9",
     "@types/semver": "^7.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@antfu/eslint-config':
         specifier: ^4.14.1
         version: 4.14.1(@vue/compiler-sfc@3.4.21)(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.3(@types/debug@4.1.12)(@types/node@24.0.3))
+      '@types/bun':
+        specifier: ^1.2.16
+        version: 1.2.16
       '@types/node':
         specifier: ^24.0.3
         version: 24.0.3
@@ -877,6 +880,9 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
+  '@types/bun@1.2.16':
+    resolution: {integrity: sha512-1aCZJ/6nSiViw339RsaNhkNoEloLaPzZhxMOYEa7OzRzO41IGg5n/7I43/ZIAW/c+Q6cT12Vf7fOZOoVIzb5BQ==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -1136,6 +1142,9 @@ packages:
   builtin-modules@5.0.0:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
+
+  bun-types@1.2.16:
+    resolution: {integrity: sha512-ciXLrHV4PXax9vHvUrkvun9VPVGOVwbbbBF/Ev1cXz12lyEZMoJpIJABOfPcN9gDJRaiKF9MVbSygLg4NXu3/A==}
 
   c12@3.0.4:
     resolution: {integrity: sha512-t5FaZTYbbCtvxuZq9xxIruYydrAGsJ+8UdP0pZzMiK2xl/gNiSOy0OxhLzHUEEb0m1QXYqfzfvyIFEmz/g9lqg==}
@@ -3315,6 +3324,10 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
+  '@types/bun@1.2.16':
+    dependencies:
+      bun-types: 1.2.16
+
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -3637,6 +3650,10 @@ snapshots:
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
 
   builtin-modules@5.0.0: {}
+
+  bun-types@1.2.16:
+    dependencies:
+      '@types/node': 24.0.3
 
   c12@3.0.4:
     dependencies:

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,3 +1,5 @@
+import type { BunLockFile } from 'bun'
+
 /**
  * The npm package manifest (package.json)
  */
@@ -16,6 +18,9 @@ export interface PackageLockManifest extends Manifest {
     '': {
       version: string
     }
+    [key: string]: {
+      version: string
+    } | undefined
   }
 }
 
@@ -37,6 +42,13 @@ export function isPackageLockManifest(
   manifest: Manifest,
 ): manifest is PackageLockManifest {
   return (typeof (manifest as PackageLockManifest).packages?.['']?.version === 'string')
+}
+
+/**
+ * Determines whether the specified manifest is bun.lock
+ */
+export function isBunLockManifest(manifest: Partial<Manifest>): manifest is BunLockFile {
+  return (typeof ((manifest as BunLockFile).workspaces[''].name) === 'string')
 }
 
 /**

--- a/src/normalize-options.ts
+++ b/src/normalize-options.ts
@@ -114,6 +114,7 @@ export async function normalizeOptions(raw: VersionBumpOptions): Promise<Normali
     raw.files = [
       'package.json',
       'package-lock.json',
+      'bun.lock',
       'packages/**/package.json',
       'jsr.json',
       'jsr.jsonc',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When publishing a workspace package with Bun, the workspace: protocol in dependencies is resolved to the version specified in bun.lock instead of the version in package.json. This causes the published package to reference incorrect versions of workspace dependencies if bumpp was used to update versions (since bumpp updates package.json but not bun.lock).

### Linked Issues

https://github.com/oven-sh/bun/issues/20477

### Additional context

While at it, also updated workspace package versions in `package-lock.json`.
