### PR TITLE
fix: add missing `-a` alias support for `--all`

### DIFF
--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -77,7 +77,7 @@ export function loadCliArgs(argv = process.argv) {
     .version(version)
     .usage('[...files]')
     .option('--preid <preid>', 'ID for prerelease')
-    .option('--all', `Include all files (default: ${bumpConfigDefaults.all})`)
+    .option('-a, --all', `Include all files (default: ${bumpConfigDefaults.all})`)
     .option('--no-git-check', `Skip git check`, { default: bumpConfigDefaults.noGitCheck })
     .option('-c, --commit [msg]', 'Commit message', { default: true })
     .option('--no-commit', 'Skip commit', { default: false })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

According to [the original docs](https://github.com/JS-DevTools/version-bump-prompt?tab=readme-ov-file#usage), `-a` should work.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
