### PR TITLE
feat: Add commit filtering for conventional commit detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "semver": "^7.7.2",
     "tinyexec": "^1.0.1",
     "tinyglobby": "^0.2.15",
+    "tiny-conventional-commits-parser": "^0.1.0",
     "yaml": "^2.8.1"
   },
   "devDependencies": {
@@ -83,7 +84,6 @@
     "eslint": "^9.37.0",
     "prompts": "^2.4.2",
     "rimraf": "^6.0.1",
-    "tiny-conventional-commits-parser": "^0.0.1",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "unbuild": "^3.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       semver:
         specifier: ^7.7.2
         version: 7.7.2
+      tiny-conventional-commits-parser:
+        specifier: ^0.1.0
+        version: 0.1.0
       tinyexec:
         specifier: ^1.0.1
         version: 1.0.1
@@ -63,9 +66,6 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
-      tiny-conventional-commits-parser:
-        specifier: ^0.0.1
-        version: 0.0.1
       tsx:
         specifier: ^4.20.6
         version: 4.20.6
@@ -2730,8 +2730,8 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  tiny-conventional-commits-parser@0.0.1:
-    resolution: {integrity: sha512-N5+AZWdBeHNSgTIaxvx0+9mFrnW4H1BbjQ84H7i3TuWSkno8Hju886hLaHZhE/hYEKrfrfl/uHurqpZJHDuYGQ==}
+  tiny-conventional-commits-parser@0.1.0:
+    resolution: {integrity: sha512-pLbcSKDnlETspEOKJvVfr8Jymb3exA8UeeRkACn7axlfbqmBr6BT0T3jI7hwPr3gVbrOQQ7DjaPhN5A86+E6Nw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -5645,7 +5645,7 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  tiny-conventional-commits-parser@0.0.1: {}
+  tiny-conventional-commits-parser@0.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -44,6 +44,7 @@ export async function parseArgs(): Promise<ParsedArgs> {
         ignoreScripts: args.ignoreScripts,
         currentVersion: args.currentVersion,
         execute: args.execute,
+        commitsPathFilter: args.commitsPathFilter,
         printCommits: args.printCommits,
         recursive: args.recursive,
         release: args.release,
@@ -95,6 +96,7 @@ export function loadCliArgs(argv = process.argv) {
     .option('--current-version <version>', 'Current version')
     .option('--print-commits', 'Print recent commits')
     .option('-x, --execute <command>', 'Commands to execute after version bumps')
+    .option('--commits-path-filter [path]', 'Path filter for commits list for latest version and conventional version (if passed with no path, the CWD will be used)')
     .option('--release <release>', `Release type or version number (e.g. 'major', 'minor', 'patch', 'prerelease', etc. default: ${bumpConfigDefaults.release})`)
     .help()
 

--- a/src/types/version-bump-options.ts
+++ b/src/types/version-bump-options.ts
@@ -158,6 +158,12 @@ export interface VersionBumpOptions {
   printCommits?: boolean
 
   /**
+   * A path filter to apply to the commits analyzed to find the latest version and conventional commits.
+   * If `true`, the CWD will be used.
+   */
+  commitsPathFilter?: string | true
+
+  /**
    * Custom function to provide the version number
    */
   customVersion?: (currentVersion: string, semver: typeof _semver) => Promise<string | void> | string | void

--- a/src/version-bump.ts
+++ b/src/version-bump.ts
@@ -4,12 +4,11 @@ import process from 'node:process'
 import { tokenizeArgs } from 'args-tokenizer'
 import c from 'ansis'
 import prompts from 'prompts'
-import { getRecentCommits } from 'tiny-conventional-commits-parser'
 import { x } from 'tinyexec'
 import { symbols } from './cli/symbols'
 import { getCurrentVersion } from './get-current-version'
 import { getNewVersion } from './get-new-version'
-import { formatVersionString, gitCommit, gitPush, gitTag } from './git'
+import { formatVersionString, getLatestCommits, gitCommit, gitPush, gitTag } from './git'
 import { Operation } from './operation'
 import { printRecentCommits } from './print-commits'
 import { runNpmScript } from './run-npm-script'
@@ -51,7 +50,7 @@ export async function versionBump(arg: (VersionBumpOptions) | string = {}): Prom
 
   const operation = await Operation.start(arg)
 
-  const commits = getRecentCommits()
+  const commits = await getLatestCommits(operation)
   if (operation.options.printCommits) {
     printRecentCommits(commits)
   }
@@ -163,10 +162,10 @@ export async function versionBumpInfo(arg: VersionBumpOptions | string = {}): Pr
     arg = { release: arg }
 
   const operation = await Operation.start(arg)
-  const commits = getRecentCommits()
 
   // Get the old and new version numbers
   await getCurrentVersion(operation)
+  const commits = await getLatestCommits(operation)
   await getNewVersion(operation, commits)
   return operation
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When working with monorepos, analyzing things on a package-by-package basis is helpful. This PR makes it possible to run in a sub-directory (or pass a path) and get a conventional commit version increment specific to that package. 

I've gotten the pass-through already released in the tiny-conventional-commits-parser package version [0.1.0](https://github.com/northword/tiny-conventional-commits-parser/releases/tag/v0.1.0), appending `-- ${path}` to it's git log command. So I've added an option, with a little parsing, and a last-tag search based on the user's tagging template that should be much better than the `tiny-conventional-commits-parser`'s own fallback which would just return commits since the last tag of any kind.

### Linked Issues

closes #99

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
