### PR TITLE
fix: only call getRecentCommits when needed

### DIFF
--- a/src/get-new-version.ts
+++ b/src/get-new-version.ts
@@ -11,7 +11,7 @@ import { isPrerelease, releaseTypes } from './release-type'
 /**
  * Determines the new version number, possibly by prompting the user for it.
  */
-export async function getNewVersion(operation: Operation, commits: GitCommit[]): Promise<Operation> {
+export async function getNewVersion(operation: Operation, commits: readonly GitCommit[]): Promise<Operation> {
   const { release } = operation.options
   const { currentVersion } = operation.state
 
@@ -35,7 +35,7 @@ export async function getNewVersion(operation: Operation, commits: GitCommit[]):
 /**
  * Returns the next version number of the specified type.
  */
-function getNextVersion(currentVersion: string, bump: BumpRelease, commits: GitCommit[]): string {
+function getNextVersion(currentVersion: string, bump: BumpRelease, commits: readonly GitCommit[]): string {
   const oldSemVer = new SemVer(currentVersion)
 
   let type: ReleaseType
@@ -68,7 +68,7 @@ function getNextVersion(currentVersion: string, bump: BumpRelease, commits: GitC
   return newSemVer.version
 }
 
-function determineSemverChange(commits: GitCommit[]) {
+function determineSemverChange(commits: readonly GitCommit[]) {
   let [hasMajor, hasMinor] = [false, false]
   for (const commit of commits) {
     if (commit.isBreaking) {
@@ -85,7 +85,7 @@ function determineSemverChange(commits: GitCommit[]) {
 /**
  * Returns the next version number for all release types.
  */
-function getNextVersions(currentVersion: string, preid: string, commits: GitCommit[]): Record<ReleaseType, string> {
+function getNextVersions(currentVersion: string, preid: string, commits: readonly GitCommit[]): Record<ReleaseType, string> {
   const next: Record<string, string> = {}
 
   const parse = semver.parse(currentVersion)
@@ -103,7 +103,7 @@ function getNextVersions(currentVersion: string, preid: string, commits: GitComm
  *
  * @returns - A tuple containing the new version number and the release type (if any)
  */
-async function promptForNewVersion(operation: Operation, commits: GitCommit[]): Promise<Operation> {
+async function promptForNewVersion(operation: Operation, commits: readonly GitCommit[]): Promise<Operation> {
   const { currentVersion } = operation.state
   const release = operation.options.release as PromptRelease
 

--- a/src/print-commits.ts
+++ b/src/print-commits.ts
@@ -28,7 +28,7 @@ const messageColorMap: Record<string, (c: string) => string> = {
   breaking: c.red,
 }
 
-export function formatParsedCommits(commits: GitCommit[]) {
+export function formatParsedCommits(commits: readonly GitCommit[]) {
   const typeLength = commits.map(({ type }) => type.length).reduce((a, b) => Math.max(a, b), 0)
   const scopeLength = commits.map(({ scope }) => scope.length).reduce((a, b) => Math.max(a, b), 0)
 
@@ -56,7 +56,7 @@ export function formatParsedCommits(commits: GitCommit[]) {
   })
 }
 
-export function printRecentCommits(commits: GitCommit[]): void {
+export function printRecentCommits(commits: readonly GitCommit[]): void {
   if (!commits.length) {
     console.log()
     console.log(c.blue`i` + c.gray` No commits since the last version`)


### PR DESCRIPTION
Previously, getRecentCommits() was called unconditionally in both
versionBump() and versionBumpInfo(). This caused issues in repositories
with no git tags because the underlying git describe command would fail
with "fatal: No names found, cannot describe anything."

This change makes getRecentCommits() only be called when commits are
actually needed:
- When printCommits is enabled
- When release type is 'prompt' (user needs to see version options)
- When release type is 'conventional' (need to determine semver change)

For explicit release types like 'major', 'minor', 'patch', 'prerelease',
etc., commits are not needed and the git describe call is now skipped.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>