### PR TITLE
chore: fix typo in `trustPolicy` value

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 shellEmulator: true
-trustPolicy: no-downgrad
+trustPolicy: no-downgrade
 onlyBuiltDependencies:
   - esbuild
   - unrs-resolver


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->
Fixes a typo in the value of `trustPolicy` in pnpm-workspace.yaml from `no-downgrad` to `no-downgrade` to fix eslint error.

### Linked Issues

fixes #106 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Error output after running the `scripts.lint` locally:

```pwsh
  2:1  error  Setting "trustPolicy" has mismatch value. Expected: "no-downgrade", Actual: "no-downgrad"  pnpm/yaml-enforce-settings

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```