### PR TITLE
feat!: add `ReleaseType` `'conventional-prerelease'`

### DIFF
--- a/src/get-new-version.ts
+++ b/src/get-new-version.ts
@@ -45,7 +45,10 @@ function getNextVersion(currentVersion: string, bump: BumpRelease, commits: GitC
     type = oldSemVer.prerelease?.length ? 'prerelease' : 'patch'
   }
   else if (bump.type === 'conventional') {
-    type = oldSemVer.prerelease?.length ? 'prerelease' : determineSemverChange(commits)
+    type = determineSemverChange(commits)
+  }
+  else if (bump.type === 'conventional-prerelease') {
+    type = oldSemVer.prerelease?.length ? 'prerelease' : `pre${determineSemverChange(commits)}`
   }
   else {
     type = bump.type
@@ -113,6 +116,7 @@ async function promptForNewVersion(operation: Operation, commits: GitCommit[]): 
         { value: 'patch', title: `${'patch'.padStart(PADDING, ' ')} ${styleText('bold', next.patch)}` },
         { value: 'next', title: `${'next'.padStart(PADDING, ' ')} ${styleText('bold', next.next)}` },
         { value: 'conventional', title: `${'conventional'.padStart(PADDING, ' ')} ${styleText('bold', next.conventional)}` },
+        { value: 'conventional-prerelease', title: `${'conventional'.padStart(PADDING, ' ')} ${styleText('bold', next['conventional-prerelease'])}` },
         ...configCustomVersion
           ? [
               { value: 'config', title: `${'from config'.padStart(PADDING, ' ')} ${styleText('bold', configCustomVersion)}` },

--- a/src/release-type.ts
+++ b/src/release-type.ts
@@ -1,11 +1,11 @@
 import type { TruncationType } from 'verkit'
 
-export type ReleaseType = TruncationType | 'next' | 'conventional'
+export type ReleaseType = TruncationType | 'next' | 'conventional' | 'conventional-prerelease'
 
 /**
  * The different types of pre-releases.
  */
-export const prereleaseTypes: ReleaseType[] = ['premajor', 'preminor', 'prepatch', 'prerelease']
+export const prereleaseTypes: ReleaseType[] = ['premajor', 'preminor', 'prepatch', 'prerelease', 'conventional-prerelease']
 
 /**
  * All possible release types.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->
Adds `ReleaseType` `'conventional-prerelease'` to support bumping from a non-prerelease version to a prerelease version based on conventional commits, and modifies the original `'conventional'` option to support the other way around.

### 🚨 Breaking Changes:
`--release conventional` now always bumps the version to a non-prerelease version based on conventional commits, and `--release conventional-prerelease` is now the one that always bumps to a prerelease version based on conventional commits.

### Linked Issues

fixes #96 
fixes #106 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Examples for what the feature achieves:

From non-prerelease:
<img width="332" height="256" alt="Screenshot 2026-02-14 165953" src="https://github.com/user-attachments/assets/bb8ff771-98ac-455f-baba-2120ffd359d0" />

From prerelease:
<img width="328" height="255" alt="Screenshot 2026-02-14 170136" src="https://github.com/user-attachments/assets/aa2ac6c3-2403-4084-ac7b-1b918e112548" />

> [!IMPORTANT]
> This pull request is branched from #108 