### PR TITLE
fix(config): prevent undefined overrides from overwriting defaults

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,9 +40,17 @@ export async function loadBumpConfig(
     cwd,
   })
 
+  // Omit undefined overrides so they don't overwrite defaults (undefined = "use default")
+  const definedOverrides = overrides
+    ? Object.fromEntries(
+        Object.entries(overrides).filter(([, v]) => v !== undefined),
+      ) as Partial<VersionBumpOptions>
+    : {}
+
   return {
+    ...bumpConfigDefaults,
     ...config,
-    ...overrides,
+    ...definedOverrides,
   }
 }
 

--- a/test/parse-args.test.ts
+++ b/test/parse-args.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { loadCliArgs } from '../src/cli/parse-args'
+import { loadBumpConfig } from '../src/config'
+import { loadCliArgs, parseArgs } from '../src/cli/parse-args'
 
 const defaultArgs = ['node', 'bumpp']
 
@@ -70,5 +71,29 @@ describe('loadCliArgs', async () => {
     const result = loadCliArgs([...defaultArgs, '--configFilePath', 'test/fixtures/build.config.ts'])
 
     expect(result.args.configFilePath).toBe('test/fixtures/build.config.ts')
+  })
+})
+
+describe('loadBumpConfig (confirm regression fix)', () => {
+  it('preserves default confirm when overrides pass confirm: undefined', async () => {
+    const config = await loadBumpConfig({ confirm: undefined })
+    expect(config.confirm).toBe(true)
+  })
+
+  it('preserves default noGitCheck when overrides pass noGitCheck: undefined', async () => {
+    const config = await loadBumpConfig({ noGitCheck: undefined })
+    expect(config.noGitCheck).toBe(true)
+  })
+
+  it('applies explicit confirm: false when --yes would be passed', async () => {
+    const config = await loadBumpConfig({ confirm: false })
+    expect(config.confirm).toBe(false)
+  })
+})
+
+describe('parseArgs (confirm regression fix)', () => {
+  it('has confirm: true when run without --yes (prompts before bump)', async () => {
+    const { options } = await parseArgs()
+    expect(options.confirm).toBe(true)
   })
 })


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackets.

### Description

After upgrading to v11, bumpp updates the version in files but no longer creates a git commit or tag. Downgrading to v10.4.1 restores the expected behavior.

**Root cause:** The switch from c12 to unconfig changed how config merging works. When parse-args sends `commit`, `tag`, `confirm`, etc. as `undefined` (when flags like `--commit` or `--yes` aren't used), the spread `{ ...config, ...overrides }` overwrites defaults with `undefined`. So `commit` and `tag` become falsy and the commit/tag steps are skipped.

**Fix:** Filter out `undefined` values from overrides before merging and use `bumpConfigDefaults` as the merge base. `undefined` = not specified = use default.

Tests added for the confirm behavior.

### Linked Issues

fixes #116

### Additional context

Tested locally: commit, tag, and confirm prompt all work as expected again.