### PR TITLE
fix(cli): prevent empty CLI files from overriding config-file `files`

### DIFF
--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -25,6 +25,18 @@ export async function parseArgs(): Promise<ParsedArgs> {
   try {
     const { args, resultArgs } = loadCliArgs()
 
+    // Strip a leading release type / version number from positional args before
+    // passing files to loadBumpConfig, so it doesn't override config-file `files`.
+    const rawFiles = [...(args['--'] || []), ...resultArgs]
+    let releaseFromArgs: string | undefined
+    if (rawFiles.length > 0) {
+      const firstArg = rawFiles[0]
+      if (firstArg === 'prompt' || isReleaseType(firstArg) || isValidVersion(firstArg)) {
+        releaseFromArgs = firstArg
+        rawFiles.shift()
+      }
+    }
+
     const parsedArgs: ParsedArgs = {
       help: args.help as boolean,
       version: args.version as boolean,
@@ -40,25 +52,15 @@ export async function parseArgs(): Promise<ParsedArgs> {
         confirm: args.yes === undefined ? undefined : !args.yes,
         noVerify: args.verify === undefined ? undefined : !args.verify,
         install: args.install,
-        files: [...(args['--'] || []), ...resultArgs],
+        files: rawFiles.length ? rawFiles : undefined,
         ignoreScripts: args.ignoreScripts,
         currentVersion: args.currentVersion,
         execute: args.execute,
         printCommits: args.printCommits,
         recursive: args.recursive,
-        release: args.release,
+        release: args.release ?? releaseFromArgs,
         configFilePath: args.configFilePath,
       }),
-    }
-
-    // If a version number or release type was specified, then it will mistakenly be added to the "files" array
-    if (parsedArgs.options.files && parsedArgs.options.files.length > 0) {
-      const firstArg = parsedArgs.options.files[0]
-
-      if (firstArg === 'prompt' || isReleaseType(firstArg) || isValidVersion(firstArg)) {
-        parsedArgs.options.release = firstArg
-        parsedArgs.options.files.shift()
-      }
     }
 
     if (parsedArgs.options.recursive && parsedArgs.options.files?.length)

--- a/test/fixtures/bump.config.ts
+++ b/test/fixtures/bump.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '../../src'
+
+export default defineConfig({
+  files: ['custom.json', 'packages/**/package.json'],
+})

--- a/test/parse-args.test.ts
+++ b/test/parse-args.test.ts
@@ -97,3 +97,17 @@ describe('parseArgs (confirm regression fix)', () => {
     expect(options.confirm).toBe(true)
   })
 })
+
+describe('loadBumpConfig (files override fix #119)', () => {
+  const fixtureDir = new URL('./fixtures', import.meta.url).pathname
+
+  it('preserves config files when no CLI files are passed (files: undefined)', async () => {
+    const config = await loadBumpConfig({ files: undefined }, fixtureDir)
+    expect(config.files).toEqual(['custom.json', 'packages/**/package.json'])
+  })
+
+  it('overrides config files when CLI files are explicitly passed', async () => {
+    const config = await loadBumpConfig({ files: ['explicit.json'] }, fixtureDir)
+    expect(config.files).toEqual(['explicit.json'])
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->

This PR fixes the config file `files` field override issue in two scenarios:

1. Running `bumpp` without passing any file arguments
2. Running `bumpp` with a release type `bump patch`

In the first scenario, the CLI always constructs a `files` array from positional args. Since `loadBumpConfig` only filters out `undefined` overrides, this empty array overwrites the user's bump.config.ts `files` settings.

In the second scenario, because `'patch'` is initially placed in the `files` array, it overrides the config, and is only stripped after config merge has already happened.

The fix moves the release-type extraction to before `loadBumpConfig` is called, and passes `files: undefined` when no actual file arguments remain, so the config-file value is preserved.

### Linked Issues

fixes #119

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
