### PR TITLE
fix: inherit stdio for git push to support windows SSH passphrase

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -35,7 +35,7 @@ export async function gitCommit(operation: Operation): Promise<Operation> {
   if (!all)
     args = [...args, ...updatedFiles]
 
-  await x('git', ['commit', ...args], { throwOnError: true })
+  await x('git', ['commit', ...args], { throwOnError: true, nodeOptions: { stdio: 'inherit' } })
 
   return operation.update({ event: ProgressEvent.GitCommit, commitMessage })
 }
@@ -69,7 +69,7 @@ export async function gitTag(operation: Operation): Promise<Operation> {
     args.push('--sign')
   }
 
-  await x('git', ['tag', ...args], { throwOnError: true })
+  await x('git', ['tag', ...args], { throwOnError: true, nodeOptions: { stdio: 'inherit' } })
 
   return operation.update({ event: ProgressEvent.GitTag, tagName })
 }
@@ -82,11 +82,11 @@ export async function gitPush(operation: Operation): Promise<Operation> {
     return operation
 
   // Push the commit
-  await x('git', ['push'], { throwOnError: true })
+  await x('git', ['push'], { throwOnError: true, nodeOptions: { stdio: 'inherit' } })
 
   if (operation.options.tag) {
     // Push the tag
-    await x('git', ['push', '--tags'], { throwOnError: true })
+    await x('git', ['push', '--tags'], { throwOnError: true, nodeOptions: { stdio: 'inherit' } })
   }
 
   return operation.update({ event: ProgressEvent.GitPush })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #81 

### 🧭 Context

On Windows, when using SSH keys or GPG signing that require a passphrase, git push, git commit, and git tag would hang or fail silently. This is because bumpp (via tinyexec) pipes stdio by default, blocking interactive prompts from appearing in the terminal.

This fix sets stdio: 'inherit' for these specific Git commands so that interactive prompts can reach the terminal properly.

### 📚 Description

tinyexec defaults to piping stdio, which prevents interactive flows that require user input. On Windows, where SSH agent forwarding is less common than on Unix systems, users frequently need to type their SSH passphrase manually. GPG signing faces the same issue when prompting for a PIN/passphrase.

Changes in src/git.ts:

Added nodeOptions: { stdio: 'inherit' } to the following commands:

git commit: Allows interactive input for GPG-signed commits.

git tag: Allows interactive input for GPG-signed tags.

git push / git push --tags: Allows SSH passphrase input (the primary issue on Windows).

By inheriting the parent process's stdio, the terminal can display prompts and accept user input as expected. This change has no impact on non-interactive environments such as CI.