### PR TITLE
feat: add type safety for release option

### DIFF
--- a/src/normalize-options.ts
+++ b/src/normalize-options.ts
@@ -89,7 +89,7 @@ export async function normalizeOptions(raw: VersionBumpOptions): Promise<Normali
   if (!raw.release || raw.release === 'prompt')
     release = { type: 'prompt', preid }
 
-  else if (isReleaseType(raw.release) || raw.release === 'next')
+  else if (isReleaseType(raw.release))
     release = { type: raw.release, preid }
 
   else

--- a/src/types/version-bump-options.ts
+++ b/src/types/version-bump-options.ts
@@ -1,6 +1,10 @@
 import type _semver from 'semver'
 import type { Operation } from '../operation'
+import type { ReleaseType } from '../release-type'
 import type { VersionBumpProgress } from './version-bump-progress'
+
+export type VersionNumber = `${number}` | `${number}${string}`
+export type VersionBumpRelease = VersionNumber | ReleaseType | 'prompt'
 
 /**
  * Options for the `versionBump()` function.
@@ -15,7 +19,7 @@ export interface VersionBumpOptions {
    *
    * Defaults to "prompt".
    */
-  release?: string
+  release?: VersionBumpRelease
 
   /**
    * The current version number to be bumpped.

--- a/src/version-bump.ts
+++ b/src/version-bump.ts
@@ -1,4 +1,4 @@
-import type { VersionBumpOptions } from './types/version-bump-options'
+import type { VersionBumpOptions, VersionBumpRelease } from './types/version-bump-options'
 import type { VersionBumpResults } from './types/version-bump-results'
 import process from 'node:process'
 import { styleText } from 'node:util'
@@ -33,7 +33,7 @@ export async function versionBump(): Promise<VersionBumpResults>
  * - A release type (e.g. "major", "minor", "patch", "prerelease", etc.)
  * - "prompt" to prompt the user for the version number
  */
-export async function versionBump(release: string): Promise<VersionBumpResults>
+export async function versionBump(release: VersionBumpRelease): Promise<VersionBumpResults>
 
 /**
  * Bumps the version number in one or more files, prompting the user if necessary.
@@ -45,7 +45,7 @@ export async function versionBump(options: VersionBumpOptions): Promise<VersionB
  * Bumps the version number in one or more files, prompting the user if necessary.
  * Optionally also commits, tags, and pushes to git.
  */
-export async function versionBump(arg: (VersionBumpOptions) | string = {}): Promise<VersionBumpResults | undefined> {
+export async function versionBump(arg: VersionBumpOptions | VersionBumpRelease = {}): Promise<VersionBumpResults | undefined> {
   if (typeof arg === 'string')
     arg = { release: arg }
 
@@ -158,7 +158,7 @@ function printSummary(operation: Operation) {
 /**
  * Bumps the version number in one or more files, prompting users if necessary.
  */
-export async function versionBumpInfo(arg: VersionBumpOptions | string = {}): Promise<Operation> {
+export async function versionBumpInfo(arg: VersionBumpOptions | VersionBumpRelease = {}): Promise<Operation> {
   if (typeof arg === 'string')
     arg = { release: arg }
 

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,0 +1,10 @@
+import type { VersionBumpOptions } from '../src'
+import { expectTypeOf, it } from 'vitest'
+
+it('release accepts release types, versions and prompt', () => {
+  expectTypeOf<'patch'>().toExtend<VersionBumpOptions['release']>()
+  expectTypeOf<'1.2.3'>().toExtend<VersionBumpOptions['release']>()
+  expectTypeOf<'prompt'>().toExtend<VersionBumpOptions['release']>()
+  // @ts-expect-error typo must be rejected
+  expectTypeOf<'prerealse'>().toExtend<VersionBumpOptions['release']>()
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #110

### 🧭 Context

<!-- Brief background and why this change is needed -->
A misspelled release type like `prerealse` currently compiles fine - `release` is typed as plain `string` - and only fails at runtime with `Invalid Version: prerealse`. 

#110 suggested narrowing the type and offered two variants (loose / strict); 
this PR implements the loose one

<!-- High-level summary of what changed -->
Narrows `VersionBumpOptions.release` and the `versionBump()` / `versionBumpInfo()` string overloads from `string` to `ReleaseType | VersionNumber | 'prompt'`, so typos fail at compile time. Also removes a now provably unreachable `'next'` check in `normalizeOptions`.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
- `VersionBumpOptions.release` and the string overloads now take `VersionBumpRelease`:

  ```ts
  export type VersionNumber = `${number}` | `${number}${string}`
  export type VersionBumpRelease = VersionNumber | ReleaseType | 'prompt'
  ```

- added `test/types.test-d.ts`, picked up by `vitest --typecheck` - it fails without this change and passes with it
- removed the `raw.release === 'next'` check in `normalizeOptions`: the narrowed type proves it unreachable, since `'next'` is already covered by `isReleaseType()`

This protects the typed surfaces - programmatic calls and `bump.config.ts`. A typo typed directly in the terminal stays out of reach of the type system (the CLI already routes unrecognized positional args to `files`).

Trade-offs reviewers should be aware of:

- technically breaking for TS users who pass a plain `string` variable as `release` - they now need to narrow or cast it
- `v1.2.3` is accepted at runtime (semver loose mode) but rejected by the new type - happy to add a `v${number}${string}` member if you'd rather keep it

Ran `pnpm lint`, `pnpm typecheck`, `pnpm vitest run --typecheck` and `pnpm build` - all green.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
