### PR TITLE
test(get-new-version): fix 'bumps `conventional` without throwing'

### DIFF
--- a/test/get-new-version.test.ts
+++ b/test/get-new-version.test.ts
@@ -53,7 +53,7 @@ describe('getNewVersion', () => {
         release: 'conventional',
       })
 
-      expect(operation.results.newVersion).toMatch(/^12\.\d+\.\d+$/)
+      expect(operation.results.newVersion).toMatch(/^\d+\.\d+\.\d+$/)
     })
 
     it('prompts without throwing', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

fixes: #129 

### 🧭 Context

Fixes the test failing due to matching the new version against a `RegExp` with a fixed major number `12` which is surpassed by the conventional bump after parsing the repository's commits which happen to include a breaking change.

### 📚 Description

Replaces the static `12` in the `RegExp` with a dynamic `\d+` to anticipate for major version bumps.
